### PR TITLE
Prevent new employees being created multiple times

### DIFF
--- a/src/main/java/ch/puzzle/marinabackend/employee/CurrentConfiguration.java
+++ b/src/main/java/ch/puzzle/marinabackend/employee/CurrentConfiguration.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.math.RoundingMode;
 
 @Entity
@@ -45,6 +44,9 @@ public class CurrentConfiguration extends AbstractEntity {
     }
 
     public BigDecimal getAmountChf() {
+        if (amountChf == null) {
+            return null;
+        }
         return round(amountChf.min(getMaxPayableAmount()));
     }
 

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -220,3 +220,16 @@ databaseChangeLog:
                   name: status
                   type: VARCHAR(50)
                   defaultValue: ACTIVE
+  - changeSet:
+      id: fixEmployeeUniqueConstraints
+      author: q-src
+      changes:
+        - addUniqueConstraint:
+            tableName: employee
+            columnNames: username
+        - addUniqueConstraint:
+            tableName: employee
+            columnNames: email
+        - addUniqueConstraint:
+            tableName: employee
+            columnNames: social_security_number

--- a/src/test/java/ch/puzzle/marinabackend/employee/EmployeeResourceDataTest.java
+++ b/src/test/java/ch/puzzle/marinabackend/employee/EmployeeResourceDataTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
 import javax.transaction.Transactional;
 import java.math.BigDecimal;
 
@@ -165,6 +166,7 @@ public class EmployeeResourceDataTest {
 
         assertThat(employeeOptional.getCurrentConfiguration().getAmountChf(), is(BigDecimal.valueOf(1000.00).setScale(2)));
     }
+
     @Test
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     public void shouldUpdateCurrentConfigurationAmountWhenBruttoUpdatedUp() {
@@ -200,5 +202,80 @@ public class EmployeeResourceDataTest {
         Employee employeeOptional = entityManager.find(Employee.class, employee.getId());
 
         assertThat(employeeOptional.getCurrentConfiguration().getAmountChf(), is(BigDecimal.valueOf(5000.00).setScale(2)));
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void shouldPreventDuplicateEmail() throws Exception {
+        //given
+        Employee employee = new Employee();
+        employee.setFirstName("Housi");
+        employee.setLastName("Mousi");
+        employee.setEmail("housi.mousi@marina.ch");
+        employee.setSocialSecurityNumber("000.0000.0000.00");
+        employee.setUsername("hmousi");
+        employee.setBruttoSalary(BigDecimal.valueOf(1000.45));
+        entityManager.persist(employee);
+        entityManager.flush();
+
+        //when
+        Employee duplicate = new Employee();
+        duplicate.setFirstName(employee.getFirstName());
+        duplicate.setLastName(employee.getLastName());
+        duplicate.setEmail(employee.getEmail());
+        duplicate.setUsername(employee.getUsername() + "different");
+        duplicate.setUsername(employee.getSocialSecurityNumber() + "different");
+        duplicate.setBruttoSalary(employee.getBruttoSalary());
+        entityManager.persist(duplicate);
+        entityManager.flush();
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void shouldPreventDuplicateUsername() throws Exception {
+        //given
+        Employee employee = new Employee();
+        employee.setFirstName("Housi");
+        employee.setLastName("Mousi");
+        employee.setEmail("housi.mousi@marina.ch");
+        employee.setSocialSecurityNumber("000.0000.0000.00");
+        employee.setUsername("hmousi");
+        employee.setBruttoSalary(BigDecimal.valueOf(1000.45));
+        entityManager.persist(employee);
+        entityManager.flush();
+
+        //when
+        Employee duplicate = new Employee();
+        duplicate.setFirstName(employee.getFirstName());
+        duplicate.setLastName(employee.getLastName());
+        duplicate.setEmail(employee.getEmail() + "different");
+        duplicate.setUsername(employee.getUsername());
+        duplicate.setSocialSecurityNumber(employee.getSocialSecurityNumber() + "different");
+        duplicate.setBruttoSalary(employee.getBruttoSalary());
+        entityManager.persist(duplicate);
+        entityManager.flush();
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void shouldPreventDuplicateSocialSecurityNumber() throws Exception {
+        //given
+        Employee employee = new Employee();
+        employee.setFirstName("Housi");
+        employee.setLastName("Mousi");
+        employee.setEmail("housi.mousi@marina.ch");
+        employee.setSocialSecurityNumber("000.0000.0000.00");
+        employee.setUsername("hmousi");
+        employee.setBruttoSalary(BigDecimal.valueOf(1000.45));
+        entityManager.persist(employee);
+        entityManager.flush();
+
+        //when
+        Employee duplicate = new Employee();
+        duplicate.setFirstName(employee.getFirstName());
+        duplicate.setLastName(employee.getLastName());
+        duplicate.setEmail(employee.getEmail() + "different");
+        duplicate.setUsername(employee.getUsername() + "different");
+        duplicate.setSocialSecurityNumber(employee.getSocialSecurityNumber());
+        duplicate.setBruttoSalary(employee.getBruttoSalary());
+        entityManager.persist(duplicate);
+        entityManager.flush();
     }
 }


### PR DESCRIPTION
This PR solves https://github.com/puzzle/marina-gui/issues/28 by applying the following fixes:

* Prevents a NullPointerException when serializing (new) users without `CurrentConfiguration`. This exception caused the GUI to re-try to create a new user.
* Adds a database migration which properly sets the unique constraints from #4. Therefore, if the GUI somehow tries to re-create an already existing user, the backend will reject those requests with an error.