### PR TITLE
Fix Docker build after Spring Boot upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ COPY src /tmp/src/src
 COPY gradle /tmp/src/gradle
 COPY build.gradle gradlew settings.gradle /tmp/src/
 
-RUN cd /tmp/src && sh gradlew build
+RUN cd /tmp/src && sh gradlew bootJar
 
 RUN cp -a /tmp/src/build/libs/*.jar /deployments/marina-backend.jar


### PR DESCRIPTION
`gradle build` apparently produces a second JAR as from Spring Boot 2.5, the `*-plain.jar`. This breakes the Docker build since we copy any `*.jar` while expecting only one file. This PR replaces running the `build` task by running the `bootJar` tasks, which creates the bootable JAR only.