### PR TITLE
fix docker build after Spring Boot upgrade (inkl. test execution)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ repositories {
     mavenCentral()
 }
 
+jar {
+    bootJar.enabled = true
+    jar.enabled = false
+}
+
 bootJar {
     manifest {
         attributes 'Implementation-Title': project.name,


### PR DESCRIPTION
gradle build produces a second JAR as from Spring Boot 2.5, the `*-plain.jar`. As mentioned in #10, this breaks the Docker build since we copy any *.jar file.

This gradle build config change tells the `gradle build` task not to create a second jar file (-plain.jar)

This PR should replace #10 