### PR TITLE
Issue/14 fix percentage calculation

### DIFF
--- a/.github/workflows/marina.yml
+++ b/.github/workflows/marina.yml
@@ -1,0 +1,25 @@
+# run all unit tests and build the marina-backend
+
+name: Marina Build Pipeline
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Build marina-backend with Gradle
+        uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
+        with:
+          arguments: clean build

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ SPRING_PROFILES_ACTIVE=local ./gradlew bootRun
 
 For further details on the development environment, please see the [corresponding documentation](devenv).
 
+Run tests:
+```shell
+./gradlew clean test
+```
+
 ## Start Application with Docker pure
 
 First start a Postgresql container with attached volume, run in the project root

--- a/build.gradle
+++ b/build.gradle
@@ -77,3 +77,7 @@ dependencies {
     testCompile('org.springframework.security:spring-security-test')
     testCompile('com.h2database:h2')
 }
+
+test {
+    useJUnitPlatform()
+}

--- a/src/main/java/ch/puzzle/marinabackend/employee/CurrentConfiguration.java
+++ b/src/main/java/ch/puzzle/marinabackend/employee/CurrentConfiguration.java
@@ -104,7 +104,7 @@ public class CurrentConfiguration extends AbstractEntity {
             return BigDecimal.valueOf(100)
                     .divide(employee.getBruttoSalary(), 10, RoundingMode.FLOOR)
                     .multiply(amountChf)
-                    .setScale(0 , RoundingMode.FLOOR);
+                    .setScale(0 , RoundingMode.HALF_UP);
         } else {
             return BigDecimal.ZERO;
         }

--- a/src/test/java/ch/puzzle/marinabackend/employee/CurrentConfigurationTest.java
+++ b/src/test/java/ch/puzzle/marinabackend/employee/CurrentConfigurationTest.java
@@ -1,0 +1,72 @@
+package ch.puzzle.marinabackend.employee;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+class CurrentConfigurationTest {
+
+    CurrentConfiguration testConfiguration;
+
+    @BeforeEach
+    void setUp() {
+        Employee employee = new Employee();
+        employee.setBruttoSalary(BigDecimal.valueOf(9100));
+        testConfiguration = new CurrentConfiguration();
+        testConfiguration.setEmployee(employee);
+    }
+
+    @Test
+    void shouldGetPercentage_Amount_91_from_9100() {
+        // given
+        testConfiguration.setAmountChf(BigDecimal.valueOf(91));
+
+        // when
+        BigDecimal result = testConfiguration.getPercentage();
+
+        // then
+        assertThat(result, is(BigDecimal.valueOf(1)));
+    }
+
+    @Test
+    void shouldGetPercentage_Amount_910_from_9100() {
+        // given
+        testConfiguration.setAmountChf(BigDecimal.valueOf(910));
+
+        // when
+        BigDecimal result = testConfiguration.getPercentage();
+
+        // then
+        assertThat(result, is(BigDecimal.valueOf(10)));
+    }
+
+    @Test
+    void shouldGetPercentage_Amount_9100_from_9100() {
+        // given
+        testConfiguration.setAmountChf(BigDecimal.valueOf(9100));
+
+        // when
+        BigDecimal result = testConfiguration.getPercentage();
+
+        // then
+        assertThat(result, is(BigDecimal.valueOf(100)));
+    }
+
+    @Test
+    void shouldGetPercentage_Amount_100_from_10000() {
+        // given
+        testConfiguration.getEmployee().setBruttoSalary(BigDecimal.valueOf(10000));
+        testConfiguration.setAmountChf(BigDecimal.valueOf(100));
+
+        // when
+        BigDecimal result = testConfiguration.getPercentage();
+
+        // then
+        assertThat(result, is(BigDecimal.valueOf(1)));
+    }
+}


### PR DESCRIPTION
Replace `RoundingMode.FLOOR` with `RoundingMode.HALF_UP` to resolve the issue that the users chosen percentage changes if the employees salary is changed - see issue #14 

I also fixed the gradle configuration to run the unit tests and added a github workflow to build the project.

The readme now describes how to run the tests locally.
